### PR TITLE
Allow browsing of YTMusic playlists and Podcast episodes

### DIFF
--- a/src/routes/browse.svelte
+++ b/src/routes/browse.svelte
@@ -87,7 +87,7 @@
           <div class="column" on:click={() => promise = browserUri(result, idx, 'avance')}>
             {result.name}
           </div>
-          {#if ['album', 'track', 'artist'].indexOf(result.type) > -1}
+          {#if ['album', 'track', 'artist', 'playlist'].indexOf(result.type) > -1}
           <div class="column is-narrow" on:click={() => handleDropdownActivation(idx)}>
             {#if options == idx}
               <FontAwesomeIcon icon={faAngleUp} class="icon" aria-haspopup="true" aria-controls="dropdown-menu"/>
@@ -161,7 +161,7 @@
   }
 
   const browserUri = async (result, idx, location) => {
-    if (['directory', 'artist', 'album'].indexOf(result.type) > -1) {
+    if (['directory', 'artist', 'album', 'playlist'].indexOf(result.type) > -1) {
       options = null
       results = await $mopidy.library.browse({uri: result.uri});
       if (location === 'back') {

--- a/src/routes/browse.svelte
+++ b/src/routes/browse.svelte
@@ -24,7 +24,7 @@
       </ul>
     </nav>
   </div>
-  {#if results.some(result => ['track'].indexOf(result.type) > -1) || results.some(result => result.type === 'directory' && result.uri.indexOf('file://') > -1)}
+  {#if results.some(checkOverallDropdownNeeded)}
   <div class="column is-narrow">
     <div class="dropdown is-right" class:is-active={showOptions} >
       <div class="dropdown-trigger" on:click={() => showOptions = !showOptions}>
@@ -87,7 +87,7 @@
           <div class="column" on:click={() => promise = browserUri(result, idx, 'avance')}>
             {result.name}
           </div>
-          {#if ['album', 'track', 'artist', 'playlist'].indexOf(result.type) > -1}
+          {#if checkItemDropdownNeeded(result)}
           <div class="column is-narrow" on:click={() => handleDropdownActivation(idx)}>
             {#if options == idx}
               <FontAwesomeIcon icon={faAngleUp} class="icon" aria-haspopup="true" aria-controls="dropdown-menu"/>
@@ -174,6 +174,16 @@
     } else if (result.type === 'track') {
       handleDropdownActivation(idx)
     }
+  }
+
+  const checkOverallDropdownNeeded = (result) => {
+    return ['track'].indexOf(result.type) > -1
+      || (result.__model__ === 'Track')
+      || (result.type === 'directory' && result.uri.indexOf('file://') > -1)
+  }
+
+  const checkItemDropdownNeeded = (result) => {
+    return ['album', 'track', 'artist', 'playlist'].indexOf(result.type) > -1
   }
 
   const handleDropdownActivation = (idx) => {


### PR DESCRIPTION
Thanks for creating Muse, it's great!

Two things didn't work for me, though:

- Mopidy-YTMusic offers auto-generated playlists under "Browse" which I could not view or play with Muse; this is fixed by the first commit.
- Mopidy-Podcast-iTunes allows browsing top podcasts on iTunes in lots of different categories. However, Muse did not display the episodes of any podcast in the "Browse" view. This is because, although Mopidy-Podcast returns albums when given a Podcast Feed, a library.browse() on these albums does not return anything. It works in Iris though because Iris uses library.lookup() by default and only resorts to library.browse() when the former does not return anything. Doing a library.lookup() on the albums returned by Mopidy-Podcast returns the list of episodes. So the last two commits in this pull request add code to resort to library.lookup() if library.browse() does not return anything.